### PR TITLE
Simple Docker Container Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node
+
+EXPOSE 3000
+
+COPY ./ /home/node/app
+
+WORKDIR /home/node/app
+
+RUN ["/usr/local/bin/npm", "install"]
+
+CMD ["/usr/local/bin/npm", "start"]

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="shortcut icon" href="docs/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#4F2F4F">
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="docs/manifest.json">
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Joseph Gordon Love-It or Leave-It</title>
+  </head>
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>


### PR DESCRIPTION
Using this `Dockerfile`, I was able to build an image and serve this application's login page on TCP port `3000`. More work remains to get the application running in this environment, like changing the `localhost` assumption within `src/modules/Settings.js`.

Once you have a Docker environment set up, you can build an image for this app:

`docker build -t jgl-love .`

and then instantiate a container that runs it:

`docker run -it --rm --name jgl-love-0 jgl-love`

Hope this helps!

Note: You can read more about deploying node.js apps on their official Docker image here https://github.com/nodejs/docker-node/blob/master/README.md#how-to-use-this-image